### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/src/textile/index.js
+++ b/src/textile/index.js
@@ -146,7 +146,7 @@ re.pattern.html_id = "[a-zA-Z][a-zA-Z\\d:]*";
 re.pattern.html_attr = "(?:\"[^\"]+\"|'[^']+'|[^>\\s]+)";
 
 const reAttr = re.compile(/^\s*([^=\s]+)(?:\s*=\s*("[^"]+"|'[^']+'|[^>\s]+))?/);
-const reComment = re.compile(/^<!--(.+?)-->/, "s");
+const reComment = re.compile(/^<!--([\s\S]*?)-->/, "s");
 const reEndTag = re.compile(/^<\/([:html_id:])([^>]*)>/);
 const reTag = re.compile(
   /^<([:html_id:])((?:\s[^=\s/]+(?:\s*=\s*[:html_attr:])?)+)?\s*(\/?)>/


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/2](https://github.com/lwe8/textile-js/security/code-scanning/2)

To fix the issue, the regular expression should be updated to correctly match HTML comments that may contain newlines. This can be achieved by modifying the regex to use a pattern that explicitly accounts for newlines, such as `[\s\S]` (which matches any character, including newlines). Additionally, the `s` flag should remain in place to ensure compatibility with the dotall behavior.

The updated regex will look like this: `^<!--([\s\S]*?)-->`. This ensures that the regex matches the entire content of an HTML comment, including any newlines.

The change should be made in the `re.compile` call on line 149 of `src/textile/index.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
