### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/src/textile/index.js
+++ b/src/textile/index.js
@@ -146,7 +146,7 @@ re.pattern.html_id = "[a-zA-Z][a-zA-Z\\d:]*";
 re.pattern.html_attr = "(?:\"[^\"]+\"|'[^']+'|[^>\\s]+)";
 
 const reAttr = re.compile(/^\s*([^=\s]+)(?:\s*=\s*("[^"]+"|'[^']+'|[^>\s]+))?/);
-const reComment = re.compile(/^<!--(.+?)-->/, "s");
+const reComment = re.compile(/^<!--([\s\S]*?)-->/, "s");
 const reEndTag = re.compile(/^<\/([:html_id:])([^>]*)>/);
 const reTag = re.compile(
   /^<([:html_id:])((?:\s[^=\s/]+(?:\s*=\s*[:html_attr:])?)+)?\s*(\/?)>/


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/2](https://github.com/lwe8/textile-js/security/code-scanning/2)

To fix the issue, the regular expression should be updated to correctly match multiline HTML comments. This can be achieved by using a more robust pattern that accounts for newlines within comments. Alternatively, a well-tested HTML parser library should be used to handle comments and other HTML structures comprehensively.

The best approach is to replace the custom regex with one that matches multiline comments, such as `<!--([\s\S]*?)-->`. This pattern uses `[\s\S]` to match any character, including newlines, and ensures that the regex captures the entire comment block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
