### PR TITLE
Potential fix for code scanning alert no. 5: Inefficient regular expression

### DIFF
--- a/src/textile/index.js
+++ b/src/textile/index.js
@@ -823,7 +823,7 @@ function $c1da35ae23756c5b$export$2e2bcd8739ae039(src, options) {
 
 (0, $1d282c06949d5561$export$2e2bcd8739ae039).pattern.txlisthd = (0, $3122b7c8007103ff$export$b94e33ed5e186b4a);
 (0, $1d282c06949d5561$export$2e2bcd8739ae039).pattern.txlisthd2 = (0, $3122b7c8007103ff$export$a3a66bd9ba3a98b6);
-const $2651df716b8fd793$var$reList = (0, $1d282c06949d5561$export$2e2bcd8739ae039).compile(/^((?:[:txlisthd:][^\0]*?(?:\r?\n|$))+)(\s*\n|$)/, "s");
+const $2651df716b8fd793$var$reList = (0, $1d282c06949d5561$export$2e2bcd8739ae039).compile(/^((?:[:txlisthd:][^\0\r\n]*(?:\r?\n|$))+)(\s*\n|$)/, "s");
 const $2651df716b8fd793$var$reItem = (0, $1d282c06949d5561$export$2e2bcd8739ae039).compile(/^([#*]+)([^\0]+?)(\n(?=[:txlisthd2:])|$)/, "s");
 function $2651df716b8fd793$var$listPad(n) {
     let s = "\n";


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/5](https://github.com/lwe8/textile-js/security/code-scanning/5)

To fix the issue, we need to remove the ambiguity in the sub-expression `[^\0]*?`. This can be achieved by replacing `[^\0]*?` with a more specific pattern that avoids ambiguity. For example, we can use a negated character class that excludes problematic characters explicitly or restructure the regular expression to eliminate the possibility of exponential backtracking.

The best way to fix this issue is to replace `[^\0]*?` with `[^\0\r\n]*`, which ensures that the repetition matches only characters that are not `\0`, `\r`, or `\n`. This eliminates ambiguity and prevents exponential backtracking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
