### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ var $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039 = $3c678dba4e
 $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.pattern.html_id = "[a-zA-Z][a-zA-Z\\d:]*";
 $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.pattern.html_attr = "(?:\"[^\"]+\"|'[^']+'|[^>\\s]+)";
 const $3c678dba4e2e903e$var$$a37e21e51a445407$var$reAttr = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^\s*([^=\s]+)(?:\s*=\s*("[^"]+"|'[^']+'|[^>\s]+))?/);
-const $3c678dba4e2e903e$var$$a37e21e51a445407$var$reComment = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^<!--(.+?)-->/, "s");
+const $3c678dba4e2e903e$var$$a37e21e51a445407$var$reComment = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^<!--([\s\S]*?)-->/, "s");
 const $3c678dba4e2e903e$var$$a37e21e51a445407$var$reEndTag = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^<\/([:html_id:])([^>]*)>/);
 const $3c678dba4e2e903e$var$$a37e21e51a445407$var$reTag = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^<([:html_id:])((?:\s[^=\s/]+(?:\s*=\s*[:html_attr:])?)+)?\s*(\/?)>/);
 const $3c678dba4e2e903e$var$$a37e21e51a445407$var$reHtmlTagBlock = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^\s*<([:html_id:](?::[a-zA-Z\d]+)*)((?:\s[^=\s/]+(?:\s*=\s*[:html_attr:])?)+)?\s*(\/?)>/);


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/3](https://github.com/lwe8/textile-js/security/code-scanning/3)

To fix the issue, the regular expression should be updated to account for multiline comments. This can be achieved by allowing the `.` character to match newlines. In JavaScript, this is done by using the `s` (dotall) flag, which allows the dot (`.`) to match any character, including newlines. Alternatively, the pattern can explicitly include `[\s\S]` to match any character, but using the `s` flag is cleaner and more modern.

The updated regular expression will be `^<!--([\s\S]*?)-->` with the `s` flag, or equivalently `^<!--(.+?)-->` with the `s` flag. This ensures that multiline comments are correctly matched.

The change will be made in the definition of `$3c678dba4e2e903e$var$$a37e21e51a445407$var$reComment` on line 113.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
