### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -748,7 +748,7 @@ function $3c678dba4e2e903e$var$$c1da35ae23756c5b$export$2e2bcd8739ae039(src, opt
 }
 $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.pattern.txlisthd = $3c678dba4e2e903e$var$$3122b7c8007103ff$export$b94e33ed5e186b4a;
 $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.pattern.txlisthd2 = $3c678dba4e2e903e$var$$3122b7c8007103ff$export$a3a66bd9ba3a98b6;
-const $3c678dba4e2e903e$var$$2651df716b8fd793$var$reList = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^((?:[:txlisthd:][^\n:]+(?:\r?\n|$))+)(\s*\n|$)/, "s");
+const $3c678dba4e2e903e$var$$2651df716b8fd793$var$reList = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^((?:[:txlisthd:](?:[^\n:]+?)(?:\r?\n|$))+)(\s*\n|$)/, "s");
 const $3c678dba4e2e903e$var$$2651df716b8fd793$var$reItem = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^([#*]+)([^\0]+?)(\n(?=[:txlisthd2:])|$)/, "s");
 function $3c678dba4e2e903e$var$$2651df716b8fd793$var$listPad(n) {
     let s = "\n";


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/4](https://github.com/lwe8/textile-js/security/code-scanning/4)

To fix the issue, we need to rewrite the regular expression to eliminate the ambiguity in the sub-expression `[^\n:]+`. The ambiguity arises because `[^\n:]` can match multiple characters in different ways, leading to exponential backtracking. A common approach is to replace `[^\n:]` with a more specific pattern that avoids ambiguity.

In this case, we can rewrite the regular expression to ensure that the repetition does not allow ambiguous matches. For example, we can replace `[^\n:]` with a pattern that explicitly excludes problematic characters or use atomic grouping to prevent backtracking.

The specific change will be made to the regular expression on line 751.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
