### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -748,7 +748,7 @@ function $3c678dba4e2e903e$var$$c1da35ae23756c5b$export$2e2bcd8739ae039(src, opt
 }
 $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.pattern.txlisthd = $3c678dba4e2e903e$var$$3122b7c8007103ff$export$b94e33ed5e186b4a;
 $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.pattern.txlisthd2 = $3c678dba4e2e903e$var$$3122b7c8007103ff$export$a3a66bd9ba3a98b6;
-const $3c678dba4e2e903e$var$$2651df716b8fd793$var$reList = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^((?:[:txlisthd:][^\0]*?(?:\r?\n|$))+)(\s*\n|$)/, "s");
+const $3c678dba4e2e903e$var$$2651df716b8fd793$var$reList = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^((?:[:txlisthd:][^:\r\n]*(?:\r?\n|$))+)(\s*\n|$)/, "s");
 const $3c678dba4e2e903e$var$$2651df716b8fd793$var$reItem = $3c678dba4e2e903e$var$$1d282c06949d5561$export$2e2bcd8739ae039.compile(/^([#*]+)([^\0]+?)(\n(?=[:txlisthd2:])|$)/, "s");
 function $3c678dba4e2e903e$var$$2651df716b8fd793$var$listPad(n) {
     let s = "\n";


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/4](https://github.com/lwe8/textile-js/security/code-scanning/4)

To fix the issue, we need to eliminate the ambiguity in the `[^\0]*?` sub-expression. This can be achieved by replacing it with a more specific pattern that avoids overlapping matches. For example, if the intent is to match any sequence of characters except null characters up to a newline or the end of the string, we can rewrite the regular expression to explicitly handle these cases without relying on ambiguous constructs. Additionally, we should ensure that the pattern is as precise as possible to minimize unnecessary backtracking.

The updated regular expression will replace `[^\0]*?` with a more deterministic construct, such as `[^:\r\n]*` (if the goal is to exclude specific characters like `:` and newline sequences). This change will remove the ambiguity and improve performance.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
