### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/src/textile/list.js
+++ b/src/textile/list.js
@@ -8,7 +8,7 @@ import { txlisthd, txlisthd2 } from "./re_ext.js";
 re.pattern.txlisthd = txlisthd;
 re.pattern.txlisthd2 = txlisthd2;
 const reList = re.compile(
-  /^((?:[:txlisthd:][^\0]*?(?:\r?\n|$))+)(\s*\n|$)/,
+  /^((?:[:txlisthd:][^\0:\r\n]*?(?:\r?\n|$))+)(\s*\n|$)/,
   "s"
 );
 const reItem = re.compile(/^([#*]+)([^\0]+?)(\n(?=[:txlisthd2:])|$)/, "s");


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/1](https://github.com/lwe8/textile-js/security/code-scanning/1)

To fix the inefficient regular expression, we need to remove the ambiguity in the repeated group. The problematic part is `[^\0]*?`, which can match any character except the null byte, and is inside a repeated group. The ambiguity arises because the repeated group can match the same substring in multiple ways, especially when the input contains many repetitions of the delimiter (e.g., `\n:`). The best way to fix this is to restrict the characters matched by `[^\0]*?` so that it cannot match the delimiter used to start the next group. In this case, we should exclude the character(s) that start a new list item (likely `:` or whatever `txlisthd` expands to). If `txlisthd` is a character class or a set of characters, we should exclude those from the inner repetition. For example, if `:` is the delimiter, we can change `[^\0]*?` to `[^\0:\r\n]*?`, so it cannot match the delimiter or line breaks. This removes the ambiguity and prevents exponential backtracking.

Edit the regular expression on line 11 in `src/textile/list.js` to replace `[^\0]*?` with `[^\0:\r\n]*?` (or, more generally, exclude all possible starting characters for the next group). No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
