### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/src/textile/html.js
+++ b/src/textile/html.js
@@ -5,7 +5,7 @@ re.pattern.html_id = "[a-zA-Z][a-zA-Z\\d:]*";
 re.pattern.html_attr = "(?:\"[^\"]+\"|'[^']+'|[^>\\s]+)";
 
 const reAttr = re.compile(/^\s*([^=\s]+)(?:\s*=\s*("[^"]+"|'[^']+'|[^>\s]+))?/);
-const reComment = re.compile(/^<!--(.+?)-->/, "s");
+const reComment = re.compile(/^<!--([\s\S]*?)-->/);
 const reEndTag = re.compile(/^<\/([:html_id:])([^>]*)>/);
 const reTag = re.compile(
   /^<([:html_id:])((?:\s[^=\s/]+(?:\s*=\s*[:html_attr:])?)+)?\s*(\/?)>/


### PR DESCRIPTION
Potential fix for [https://github.com/lwe8/textile-js/security/code-scanning/3](https://github.com/lwe8/textile-js/security/code-scanning/3)

To fix the problem, we should update the regular expression used to match HTML comments so that it matches newlines within comments, regardless of the "s" (dotAll) flag. The most robust way is to replace `(.+?)` with `([\s\S]*?)`, which matches any character (including newlines) in a non-greedy way. This change should be made in the definition of `reComment` on line 8 of `src/textile/html.js`. No additional imports or method changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
